### PR TITLE
Validation of r01/r02 implemented - if two matvurd records point to a…

### DIFF
--- a/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
+++ b/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
@@ -56,19 +56,17 @@ public class MatVurdR01R02CheckRecordsAction extends AbstractRawRepoAction {
                 }
                 else if ("032".contains(field.getName())) {
                     for (MarcSubField subField : field.getSubfields()) {
-                        if ("x".equals(subField.getName())) {
-                            if (subField.getValue().startsWith("LED")) {
-                                hasLED = true;
-                            }
+                        if ("x".equals(subField.getName()) && subField.getValue().startsWith("LED")) {
+                            hasLED = true;
+                            break;
                         }
                     }
                 }
                 else if ("700".contains(field.getName())) {
                     for (MarcSubField subField : field.getSubfields()) {
-                        if ("f".equals(subField.getName())) {
-                            if ("skole".equals(subField.getValue())) {
-                                hasSchool = 1;
-                            }
+                        if ("f".equals(subField.getName()) && "skole".equals(subField.getValue())) {
+                            hasSchool = 1;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
… single 870970 record, then one must have 700*fskole - max two matvurd records.

If there is one matvurd record that have 032xLED... then there can be up to four matvurd records - if four, then there must be one with 700*fskole

Restructuring code a bit

Use of javascript interface functions changed to pure java

PMD fix

Auditors:atm