### PR TITLE
Validation of r01/r02 implemented - if two matvurd records point to a…

### DIFF
--- a/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
+++ b/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
@@ -126,12 +126,12 @@ public class MatVurdR01R02CheckRecordsAction extends AbstractRawRepoAction {
                     Max two records and only one with skole
                  */
                 if (hasLED) {
-                    // Up to 3 records are allowed (excluding the current) but only one school
-                    if (count > 3) {
-                        final String message = String.format(state.getMessages().getString("more.than.three.matvurd.hits"), id);
+                    // Up to 4 records are allowed (excluding the current) but only one school
+                    if (count > 4) {
+                        final String message = String.format(state.getMessages().getString("more.than.four.matvurd.hits"), id);
                         return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
                     }
-                    if (count == 3 && hasSchool != 1) {
+                    if (count == 4 && hasSchool != 1) {
                         final String message = String.format(state.getMessages().getString("wrong.count.of.school.record"), id);
                         return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
                     }

--- a/src/main/resources/actions_da_DK.properties
+++ b/src/main/resources/actions_da_DK.properties
@@ -65,7 +65,7 @@ parent.does.not.exist=Den overliggende post (%s:%s) findes ikke
 
 # Matvurd messages
 more.than.two.matvurd.hits=Der er ingen LED kode og mere end to vurderinger på værket %s
-more.than.three.matvurd.hits=Der er LED kode og mere end tre vurderinger på værket %s
+more.than.four.matvurd.hits=Der er LED kode og mere end fire vurderinger på værket %s
 wrong.count.of.school.record=Værket %s har ingen eller mere end en skolevurdering og der er flere matvurd poster
 
 


### PR DESCRIPTION
… single 870970 record, then one must have 700*fskole - max two matvurd records.

If there is one matvurd record that have 032xLED... then there can be up to four matvurd records - if four, then there must be one with 700*fskole

Restructuring code a bit

Use of javascript interface functions changed to pure java

PMD fix

Four instead of three allowed in LED

Auditors:atm