### PR TITLE
Validation of r01/r02 implemented - if two matvurd records point to a…

### DIFF
--- a/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
+++ b/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
@@ -54,6 +54,13 @@ public class MatVurdR01R02CheckRecordsAction extends AbstractRawRepoAction {
                         }
                     }
                 }
+                else if ("004".contains(field.getName())) {
+                    for (MarcSubField subField : field.getSubfields()) {
+                        if ("r".equals(subField.getName()) && "d".equals(subField.getValue())) {
+                                return result = ServiceResult.newOkResult();
+                        }
+                    }
+                }
                 else if ("032".contains(field.getName())) {
                     for (MarcSubField subField : field.getSubfields()) {
                         if ("x".equals(subField.getName()) && subField.getValue().startsWith("LED")) {


### PR DESCRIPTION
… single 870970 record, then one must have 700*fskole - max two matvurd records.

If there is one matvurd record that have 032xLED... then there can be up to four matvurd records - if four, then there must be one with 700*fskole

Restructuring code a bit

Use of javascript interface functions changed to pure java

PMD fix

Four instead of three allowed in LED

Ignoring delete records

Auditors:atm