### PR TITLE
Validation of r01/r02 implemented - if two matvurd records point to a…

### DIFF
--- a/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
+++ b/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
@@ -138,21 +138,17 @@ public class MatVurdR01R02CheckRecordsAction extends AbstractRawRepoAction {
                         final String message = String.format(state.getMessages().getString("more.than.four.matvurd.hits"), id);
                         return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
                     }
-                    if (count == 4 && hasSchool != 1) {
-                        final String message = String.format(state.getMessages().getString("wrong.count.of.school.record"), id);
-                        return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
-                    }
-                    if (hasSchool > 1) {
-                        final String message = String.format(state.getMessages().getString("wrong.count.of.school.record"), id);
-                        return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
-                    }
                 } else {
                     if (count > 2) {
                         final String message = String.format(state.getMessages().getString("more.than.two.matvurd.hits"), id);
                         return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
                     }
-                    if (count == 2 && hasSchool != 1) {
-                        final String message = String.format(state.getMessages().getString("wrong.count.of.school.record"), id);
+                    if (count == 2 && hasSchool == 0) {
+                        final String message = String.format(state.getMessages().getString("zero.count.of.school.record"), id);
+                        return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
+                    }
+                    if (count == 2 && hasSchool == 2) {
+                        final String message = String.format(state.getMessages().getString("two.count.of.school.record"), id);
                         return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
                     }
                 }

--- a/src/main/resources/actions_da_DK.properties
+++ b/src/main/resources/actions_da_DK.properties
@@ -64,9 +64,10 @@ sanity.check.failed=Indholdet i forespørgslen overholder ikke minimumskrav for 
 parent.does.not.exist=Den overliggende post (%s:%s) findes ikke
 
 # Matvurd messages
-more.than.two.matvurd.hits=Der er ingen LED kode og mere end to vurderinger på værket %s
+more.than.two.matvurd.hits=Der er mere end to vurderinger på værket %s
 more.than.four.matvurd.hits=Der er LED kode og mere end fire vurderinger på værket %s
-wrong.count.of.school.record=Værket %s har ingen eller mere end en skolevurdering og der er flere matvurd poster
+zero.count.of.school.record=Værket %s har ingen skolevurdering og der er to matvurd poster
+two.count.of.school.record=Værket %s har to skolevurderinger på to matvurd poster
 
 
 # Classification messages


### PR DESCRIPTION
… single 870970 record, then one must have 700*fskole - max two matvurd records.

If there is one matvurd record that have 032xLED... then there can be up to four matvurd records - if four, then there must be one with 700*fskole

Restructuring code a bit

Use of javascript interface functions changed to pure java

PMD fix

Four instead of three allowed in LED

Ignoring delete records

Even more lazy check when LED - no school check

Auditors:atm