### PR TITLE
Validation of r01/r02 implemented - if two matvurd records point to a…

### DIFF
--- a/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
+++ b/src/main/java/dk/dbc/updateservice/actions/MatVurdR01R02CheckRecordsAction.java
@@ -103,6 +103,8 @@ public class MatVurdR01R02CheckRecordsAction extends AbstractRawRepoAction {
             for (String id : ids) {
                 // for each id we get relations and look at content in those
                 int count = 1;
+                boolean idHasLED = hasLED;
+                int idHasSchool = hasSchool;
                 final RecordId recordId = new RecordId(id, RawRepo.COMMON_AGENCY);
                 final Set<RecordId> childrenIds = state.getRawRepo().children(recordId);
                 for (RecordId recordId1 : childrenIds) {
@@ -111,13 +113,13 @@ public class MatVurdR01R02CheckRecordsAction extends AbstractRawRepoAction {
                     if (RawRepo.MATVURD_AGENCY == reader.getAgencyIdAsInt() && !thisId.equals(reader.getRecordId())) {
                         for (String content : reader.getValues("032", "x")) {
                             if (content.startsWith("LED")) {
-                                hasLED = true;
+                                idHasLED = true;
                                 break;
                             }
                         }
                         for (String content : reader.getValues("700", "f")) {
                             if (content.equals("skole")) {
-                                hasSchool++;
+                                idHasSchool++;
                                 break;
                             }
                         }
@@ -132,7 +134,7 @@ public class MatVurdR01R02CheckRecordsAction extends AbstractRawRepoAction {
                 Without LED :
                     Max two records and only one with skole
                  */
-                if (hasLED) {
+                if (idHasLED) {
                     // Up to 4 records are allowed (excluding the current) but only one school
                     if (count > 4) {
                         final String message = String.format(state.getMessages().getString("more.than.four.matvurd.hits"), id);
@@ -143,11 +145,11 @@ public class MatVurdR01R02CheckRecordsAction extends AbstractRawRepoAction {
                         final String message = String.format(state.getMessages().getString("more.than.two.matvurd.hits"), id);
                         return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
                     }
-                    if (count == 2 && hasSchool == 0) {
+                    if (count == 2 && idHasSchool == 0) {
                         final String message = String.format(state.getMessages().getString("zero.count.of.school.record"), id);
                         return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
                     }
-                    if (count == 2 && hasSchool == 2) {
+                    if (count == 2 && idHasSchool == 2) {
                         final String message = String.format(state.getMessages().getString("two.count.of.school.record"), id);
                         return ServiceResult.newErrorResult(UpdateStatusEnumDTO.FAILED, message);
                     }


### PR DESCRIPTION
… single 870970 record, then one must have 700*fskole - max two matvurd records.

If there is one matvurd record that have 032xLED... then there can be up to four matvurd records - if four, then there must be one with 700*fskole

Restructuring code a bit

Use of javascript interface functions changed to pure java

PMD fix

Four instead of three allowed in LED

Ignoring delete records

Even more lazy check when LED - no school check

School count and LED shall be done individually

Auditors:atm