### PR TITLE
No more check for cataloging level of RET records.

### DIFF
--- a/.idea/runConfigurations/test_ocb_single.xml
+++ b/.idea/runConfigurations/test_ocb_single.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="test-ocb-single" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/../ocb-tools/target/dist/ocb-tools-1.0.0/bin/ocb-test-1.0-SNAPSHOT-jar-with-dependencies.jar" />
-    <option name="PROGRAM_PARAMETERS" value="run -c testrun --summary change-universe-volume-relation" />
+    <option name="PROGRAM_PARAMETERS" value="run -c testrun --summary hostile-takeover" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/../opencat-business" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="ALTERNATIVE_JRE_PATH" value="11.0.7" />

--- a/src/main/java/dk/dbc/updateservice/actions/AuthenticateRecordAction.java
+++ b/src/main/java/dk/dbc/updateservice/actions/AuthenticateRecordAction.java
@@ -18,7 +18,6 @@ import dk.dbc.vipcore.libraryrules.VipCoreLibraryRulesConnector;
 
 import javax.ejb.EJBException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -210,14 +209,6 @@ public class AuthenticateRecordAction extends AbstractRawRepoAction {
                 log.info("Owner is RET");
                 if (!state.getVipCoreService().hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_RET_RECORD)) {
                     return createErrorReply(resourceBundle.getString("update.common.record.error"));
-                }
-                log.info("New value of 008 *v is {}", reader.getValue("008", "v"));
-                log.info("Current value of 008 *v is {}", curReader.getValue("008", "v"));
-                if ("4".equals(curReader.getValue("008", "v"))) {
-                    final List<String> allowedKatValues = Arrays.asList("0", "1", "5");
-                    if (!allowedKatValues.contains(reader.getValue("008", "v"))) {
-                        return createErrorReply(resourceBundle.getString("update.common.record.katalogiseringsniveau.error"));
-                    }
                 }
                 return createOkReply();
             }

--- a/src/main/java/dk/dbc/updateservice/update/NoteAndSubjectExtensionsHandler.java
+++ b/src/main/java/dk/dbc/updateservice/update/NoteAndSubjectExtensionsHandler.java
@@ -120,8 +120,6 @@ public class NoteAndSubjectExtensionsHandler {
             final String recId = reader.getRecordId();
             final Map<String, MarcRecord> currentRecordCollection = rawRepo.fetchRecordCollection(recId, reader.getAgencyIdAsInt());
             result = ExpandCommonMarcRecord.expandMarcRecord(currentRecordCollection, recId);
-            String s1 = marcRecord.toString();
-            String s2 = result.toString();
         } catch (RawRepoException e) {
             throw new UpdateException("Exception while expanding the records", e);
         }

--- a/src/main/java/dk/dbc/updateservice/update/NoteAndSubjectExtensionsHandler.java
+++ b/src/main/java/dk/dbc/updateservice/update/NoteAndSubjectExtensionsHandler.java
@@ -53,7 +53,7 @@ public class NoteAndSubjectExtensionsHandler {
      * Handle classification fields. The following rules need to be followed.
      * if 652 fields are equal, then just add them
      * if not, then look closer at the content :
-     * if current has code "uden klassemærke" then look at the record and the agencys rights
+     * if current has code "uden klassemærke" then look at the record and the agency's rights
      * if disputas and the agency may add dk5 to such, then do it
      * if not, then error.
      */
@@ -77,7 +77,7 @@ public class NoteAndSubjectExtensionsHandler {
                                     result.getFields().add(copyWithNewAmpersand(new652Field, groupId));
                                 }
                             } else {
-                                // This should not be possible due to other protections, but if they for some reason dissapears, this
+                                // This should not be possible due to other protections, but if they for some reason disappears, this
                                 // will prevent deleting 652 - please note that there are no testcase to check this
                                 final String msg = messages.getString("update.dbc.record.652.no.delete");
                                 log.error("Unable to create sub actions due to an error: {}", msg);
@@ -106,7 +106,30 @@ public class NoteAndSubjectExtensionsHandler {
     }
 
     /**
-     * Handles modifiying subjectfields given in EXTENDABLE_CONTROLLED_SUBJECT_FIELDS
+     * Creates an extended record of some unexpanded record. Please note, this was first done
+     * because the callChecked interface couldn't handle three exceptions, but are now used at two
+     * places
+     * @param marcRecord the record to expand
+     * @return expanded record
+     * @throws UpdateException there is something rotten in rawrepo
+     */
+    MarcRecord getExpandedRecord(MarcRecord marcRecord) throws UpdateException {
+        MarcRecord result;
+        try {
+            final MarcRecordReader reader = new MarcRecordReader(marcRecord);
+            final String recId = reader.getRecordId();
+            final Map<String, MarcRecord> currentRecordCollection = rawRepo.fetchRecordCollection(recId, reader.getAgencyIdAsInt());
+            result = ExpandCommonMarcRecord.expandMarcRecord(currentRecordCollection, recId);
+            String s1 = marcRecord.toString();
+            String s2 = result.toString();
+        } catch (RawRepoException e) {
+            throw new UpdateException("Exception while expanding the records", e);
+        }
+        return result;
+    }
+
+    /**
+     * Handles modifying subject fields given in EXTENDABLE_CONTROLLED_SUBJECT_FIELDS
      * The mechanism is pretty simple, if any of the fields are owned by dbc, then it isn't allowed for libraries to modify any
      * If none are dbc fields, then the old fields are deleted and the new ones are added with the updating agency as owner
      * @param result            the resulting record
@@ -116,12 +139,16 @@ public class NoteAndSubjectExtensionsHandler {
      * @throws UpdateException  attempt to modify dbc owned subjects detected
      */
     void addSubjectFields(MarcRecord result, MarcRecord marcRecord, MarcRecord curRecord, String groupId ) throws UpdateException {
+        final MarcRecord expandedCurrentRecord;
+        expandedCurrentRecord = getExpandedRecord(curRecord);
         final List<MarcField> newControlledSubjectFields = marcRecord.getFields().stream()
                 .filter(field -> field.getName().matches(EXTENDABLE_CONTROLLED_SUBJECT_FIELDS)).collect(Collectors.toList());
         final List<MarcField> currentControlledSubjectFields = curRecord.getFields().stream()
                 .filter(field -> field.getName().matches(EXTENDABLE_CONTROLLED_SUBJECT_FIELDS)).collect(Collectors.toList());
+        final List<MarcField> currentExpandedControlledSubjectFields = expandedCurrentRecord.getFields().stream()
+                .filter(field -> field.getName().matches(EXTENDABLE_CONTROLLED_SUBJECT_FIELDS)).collect(Collectors.toList());
 
-        if (marcFieldsEqualsIgnoreAmpersand(newControlledSubjectFields, currentControlledSubjectFields)) {
+        if (marcFieldsEqualsIgnoreAmpersand(newControlledSubjectFields, currentExpandedControlledSubjectFields)) {
             // Controlled subject field are identical, so just copy the existing ones over
             result.getFields().addAll(currentControlledSubjectFields);
         } else {
@@ -139,7 +166,7 @@ public class NoteAndSubjectExtensionsHandler {
         // Handle (non-controlled) subject fields. These fields are handled individually
         final List<MarcField> newSubjectFields = marcRecord.getFields().stream()
                 .filter(field -> field.getName().matches(EXTENDABLE_SUBJECT_FIELDS)).collect(Collectors.toList());
-        final List<MarcField> currentSubjectFields = curRecord.getFields().stream()
+        final List<MarcField> currentSubjectFields = expandedCurrentRecord.getFields().stream()
                 .filter(field -> field.getName().matches(EXTENDABLE_SUBJECT_FIELDS)).collect(Collectors.toList());
 
         if (marcFieldsEqualsIgnoreAmpersand(newSubjectFields, currentSubjectFields)) {
@@ -174,7 +201,7 @@ public class NoteAndSubjectExtensionsHandler {
     /**
      * See whether there is a *&amp; 7xxxxx subfield or not.
      * Just for the fun of it, some dbc owned fields have subfields *&amp;0 and *&amp;1, so it's not enough to check if *&amp; exists
-     * @param fields The fieldlist to check
+     * @param fields The field list to check
      * @return return true if there isn't a *&amp;7xxxxx subfield otherwise false
      */
     private boolean isDbcField(List<MarcField> fields) {
@@ -197,14 +224,14 @@ public class NoteAndSubjectExtensionsHandler {
      * Look up the field in current record - if there is a field with *&amp;1 or no *&amp; at all, then it is a dbc field, and it is not allowed
      * to add/modify the field - that is, if the incoming record has a note field that differ from the current note fields,
      * ignoring *&amp; subfields, then return an error.
-     * If there are no dbc notefield, then add incoming notes (thereby destroying existing)
+     * If there are no dbc note field, then add incoming notes (thereby destroying existing)
      * In all cases the *&amp; subfield is given the updating agency as owner
      * Update notes is impossible since we don't receive a "change this note to that" request, just a record with the content the updater want.
      * @param result           The marcrecord containing the result of the function
      * @param marcRecord       The updating record
      * @param curRecord        The record found in rawrepo
-     * @param groupId          The updating librarys agencyid
-     * @throws UpdateException Something not allowed has happend
+     * @param groupId          The updating library's agency id
+     * @throws UpdateException Something not allowed has happened
      */
     private void addNoteFields(MarcRecord result, MarcRecord marcRecord, MarcRecord curRecord, String groupId ) throws UpdateException {
         String[] fields = EXTENDABLE_NOTE_FIELDS.split("\\|");
@@ -250,6 +277,7 @@ public class NoteAndSubjectExtensionsHandler {
     }
 
     /**
+     * Update the incoming record with relevant fields - notes, subjects etc.
      *
      * @param marcRecord        The incoming record
      * @param groupId           The library number for the updating library
@@ -624,7 +652,8 @@ public class NoteAndSubjectExtensionsHandler {
      * @return List of validation errors (ok returns empty list)
      * @throws UpdateException if communication with RawRepo or OpenAgency fails
      */
-    public List<MessageEntryDTO> authenticateCommonRecordExtraFields(MarcRecord marcRecord, String groupId) throws UpdateException, VipCoreException {
+    public List<MessageEntryDTO> authenticateCommonRecordExtraFields(MarcRecord marcRecord, String groupId)
+            throws UpdateException, VipCoreException {
         return LOGGER.<List<MessageEntryDTO>, UpdateException, VipCoreException>callChecked2(log -> {
             final List<MessageEntryDTO> result = new ArrayList<>();
             final MarcRecordReader reader = new MarcRecordReader(marcRecord);
@@ -670,17 +699,22 @@ public class NoteAndSubjectExtensionsHandler {
             }
 
             if (!vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_SUBJECTS)) {
-                log.info("AgencyId {} does not have feature AUTH_COMMON_SUBJECTS in vipcore - checking for changed note fields", groupId);
+                final MarcRecord expandedCurrentRecord;
+                expandedCurrentRecord = getExpandedRecord(curRecord);
+
+                log.info("AgencyId {} does not have feature AUTH_COMMON_SUBJECTS in vipcore - checking for changed subject fields", groupId);
                 // Check if all fields in the incoming record are in the existing record
                 for (MarcField field : marcRecord.getFields()) {
-                    if (field.getName().matches(EXTENDABLE_CONTROLLED_SUBJECT_FIELDS) && isFieldChangedInOtherRecord(field, curRecord)) {
+                    if (field.getName().matches(EXTENDABLE_CONTROLLED_SUBJECT_FIELDS) &&
+                            isFieldChangedInOtherRecord(field, expandedCurrentRecord)) {
                         final String message = String.format(resourceBundle.getString("notes.subjects.edit.field.error"), groupId, field.getName(), recId);
                         result.add(createMessageDTO(message));
                     }
                 }
                 // Check if all fields in the existing record are in the incoming record
-                for (MarcField field : curRecord.getFields()) {
-                    if (field.getName().matches(EXTENDABLE_CONTROLLED_SUBJECT_FIELDS) && isFieldChangedInOtherRecord(field, marcRecord)) {
+                for (MarcField field : expandedCurrentRecord.getFields()) {
+                    if (field.getName().matches(EXTENDABLE_CONTROLLED_SUBJECT_FIELDS) &&
+                            isFieldChangedInOtherRecord(field, marcRecord)) {
                         final String fieldName = field.getName();
                         if (curReader.getFieldAll(fieldName).size() != reader.getFieldAll(fieldName).size()) {
                             final String message = String.format(resourceBundle.getString("notes.subjects.delete.field.error"), groupId, fieldName, recId);

--- a/src/test/java/dk/dbc/updateservice/actions/AuthenticateRecordActionTest.java
+++ b/src/test/java/dk/dbc/updateservice/actions/AuthenticateRecordActionTest.java
@@ -313,35 +313,6 @@ class AuthenticateRecordActionTest {
     }
 
     @Test
-    void testPerformAction_OK_NotCommonNationalRecord_ExistingRecord_RETOwner_WrongCatLevel() throws Exception {
-        MarcRecord record = AssertActionsUtil.loadRecord(AssertActionsUtil.LOCAL_SINGLE_RECORD_RESOURCE);
-        MarcRecordReader reader = new MarcRecordReader(record);
-        new MarcRecordWriter(record).addOrReplaceSubfield("001", "b", "870970");
-        new MarcRecordWriter(record).addOrReplaceSubfield("008", "v", "4");
-        new MarcRecordWriter(record).addOrReplaceSubfield("996", "a", "RET");
-        String groupId = "830010";
-        List<MarcField> l1 = new ArrayList<>();
-        List<MarcField> l2 = new ArrayList<>();
-
-        AuthenticationDTO authenticationDTO = new AuthenticationDTO();
-        authenticationDTO.setGroupId(groupId);
-        UpdateServiceRequestDTO updateServiceRequestDTO = new UpdateServiceRequestDTO();
-        updateServiceRequestDTO.setAuthenticationDTO(authenticationDTO);
-        state.setUpdateServiceRequestDTO(updateServiceRequestDTO);
-
-        when(state.getVipCoreService().hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_ROOT)).thenReturn(false);
-        when(state.getNoteAndSubjectExtensionsHandler().isPublishedDBCRecord(record)).thenReturn(false);
-        when(state.getNoteAndSubjectExtensionsHandler().marcFieldsEqualsIgnoreAmpersand(l1, l2 )).thenReturn(true);
-        when(state.getRawRepo().recordExists(reader.getRecordId(), reader.getAgencyIdAsInt())).thenReturn(true);
-        when(state.getRawRepo().fetchRecord(reader.getRecordId(), RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(record, MarcXChangeMimeType.MARCXCHANGE));
-        when(state.getVipCoreService().hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_RET_RECORD)).thenReturn(true);
-
-        AuthenticateRecordAction instance = new AuthenticateRecordAction(state, record);
-        ServiceResult actual = instance.performAction();
-        assertThat(actual, is(createExpectedErrorReply("update.common.record.katalogiseringsniveau.error")));
-    }
-
-    @Test
     void testPerformAction_OK_NotCommonNationalRecord_ExistingRecord_RETOwner_CorrectCatLevel() throws Exception {
         MarcRecord record = AssertActionsUtil.loadRecord(AssertActionsUtil.LOCAL_SINGLE_RECORD_RESOURCE);
         MarcRecordReader reader = new MarcRecordReader(record);

--- a/src/test/java/dk/dbc/updateservice/update/NoteAndSubjectExtensionsHandlerTest.java
+++ b/src/test/java/dk/dbc/updateservice/update/NoteAndSubjectExtensionsHandlerTest.java
@@ -342,6 +342,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_NOTES)).thenReturn(true);
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_SUBJECTS)).thenReturn(true);
 
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(currentReader.getRecordId(), currentRecord);
+        when(rawRepo.fetchRecordCollection(currentReader.getRecordId(), currentReader.getAgencyIdAsInt())).thenReturn(result);
+
         NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, ResourceBundles.getBundle("actions"));
 
         try {
@@ -381,6 +385,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_NOTES)).thenReturn(true);
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_SUBJECTS)).thenReturn(true);
 
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(currentReader.getRecordId(), currentRecord);
+        when(rawRepo.fetchRecordCollection(currentReader.getRecordId(), currentReader.getAgencyIdAsInt())).thenReturn(result);
+
         NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, ResourceBundles.getBundle("actions"));
 
         assertThat(instance.extensionRecordDataForRawRepo(record, groupId), is(expectedRecord));
@@ -410,6 +418,10 @@ class NoteAndSubjectExtensionsHandlerTest {
 
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_NOTES)).thenReturn(true);
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_SUBJECTS)).thenReturn(true);
+
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(currentReader.getRecordId(), currentRecord);
+        when(rawRepo.fetchRecordCollection(currentReader.getRecordId(), currentReader.getAgencyIdAsInt())).thenReturn(result);
 
         NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, ResourceBundles.getBundle("actions"));
 
@@ -454,6 +466,10 @@ class NoteAndSubjectExtensionsHandlerTest {
 
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_NOTES)).thenReturn(true);
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_SUBJECTS)).thenReturn(true);
+
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(currentReader.getRecordId(), currentRecord);
+        when(rawRepo.fetchRecordCollection(currentReader.getRecordId(), currentReader.getAgencyIdAsInt())).thenReturn(result);
 
         NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, ResourceBundles.getBundle("actions"));
 
@@ -753,6 +769,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(rawRepo.recordExists(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(true);
         when(rawRepo.fetchRecord(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(existingRecord, MarcXChangeMimeType.MARCXCHANGE));
 
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
+
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
         assertThat(instance.extensionRecordDataForRawRepo(newRecord, groupId), is(expectedRecord));
@@ -770,6 +790,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_SUBJECTS)).thenReturn(true);
         when(rawRepo.recordExists(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(true);
         when(rawRepo.fetchRecord(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(existingRecord, MarcXChangeMimeType.MARCXCHANGE));
+
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
 
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
@@ -794,6 +818,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(rawRepo.children(new RecordId(bibliographicRecordId, RawRepo.COMMON_AGENCY))).thenReturn(new HashSet<>(List.of(volumeRecordId)));
         when(rawRepo.fetchRecord(bibliographicRecordIdVolume, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(volumeRecord, MarcXChangeMimeType.MARCXCHANGE));
 
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
+
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
         assertThat(instance.extensionRecordDataForRawRepo(newRecord, groupId), is(expectedRecord));
@@ -812,6 +840,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(rawRepo.recordExists(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(true);
         when(rawRepo.fetchRecord(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(existingRecord, MarcXChangeMimeType.MARCXCHANGE));
 
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
+
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
         assertThat(instance.extensionRecordDataForRawRepo(newRecord, groupId), is(expectedRecord));
@@ -828,6 +860,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_SUBJECTS)).thenReturn(true);
         when(rawRepo.recordExists(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(true);
         when(rawRepo.fetchRecord(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(existingRecord, MarcXChangeMimeType.MARCXCHANGE));
+
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
 
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
@@ -857,6 +893,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(rawRepo.recordExists(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(true);
         when(rawRepo.fetchRecord(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(existingRecord, MarcXChangeMimeType.MARCXCHANGE));
 
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
+
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
         assertThat(instance.extensionRecordDataForRawRepo(newRecord, groupId), is(expectedRecord));
@@ -875,6 +915,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(rawRepo.recordExists(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(true);
         when(rawRepo.fetchRecord(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(existingRecord, MarcXChangeMimeType.MARCXCHANGE));
 
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
+
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
         assertThat(instance.extensionRecordDataForRawRepo(newRecord, groupId), is(expectedRecord));
@@ -892,6 +936,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_SUBJECTS)).thenReturn(true);
         when(rawRepo.recordExists(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(true);
         when(rawRepo.fetchRecord(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(existingRecord, MarcXChangeMimeType.MARCXCHANGE));
+
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
 
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
@@ -916,6 +964,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(rawRepo.children(new RecordId(bibliographicRecordId, RawRepo.COMMON_AGENCY))).thenReturn(new HashSet<>(List.of(volumeRecordId)));
         when(rawRepo.fetchRecord(volumeBibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(volumeRecord, MarcXChangeMimeType.MARCXCHANGE));
 
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
+
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
         assertThat(instance.extensionRecordDataForRawRepo(newRecord, groupId), is(expectedRecord));
@@ -934,6 +986,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(rawRepo.recordExists(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(true);
         when(rawRepo.fetchRecord(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(existingRecord, MarcXChangeMimeType.MARCXCHANGE));
 
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
+
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 
         assertThat(instance.extensionRecordDataForRawRepo(newRecord, groupId), is(expectedRecord));
@@ -951,6 +1007,10 @@ class NoteAndSubjectExtensionsHandlerTest {
         when(vipCoreService.hasFeature(groupId, VipCoreLibraryRulesConnector.Rule.AUTH_COMMON_SUBJECTS)).thenReturn(true);
         when(rawRepo.recordExists(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(true);
         when(rawRepo.fetchRecord(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(AssertActionsUtil.createRawRepoRecord(existingRecord, MarcXChangeMimeType.MARCXCHANGE));
+
+        Map<String, MarcRecord> result = new HashMap<>();
+        result.put(bibliographicRecordId, existingRecord);
+        when(rawRepo.fetchRecordCollection(bibliographicRecordId, RawRepo.COMMON_AGENCY)).thenReturn(result);
 
         final NoteAndSubjectExtensionsHandler instance = new NoteAndSubjectExtensionsHandler(vipCoreService, rawRepo, resourceBundle);
 

--- a/src/test/resources/dk/dbc/updateservice/records/record-1-existing.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-1-existing.marc
@@ -11,8 +11,8 @@
 532 00 *& 1 *a Med litteraturhenvisninger
 652 00 *m 46.4 *b Løkken
 652 00 *p 46.4 *b Blokhus
-700 00 *5 870979 *6 68484499 *4 aut
-700 00 *5 870979 *6 68493579 *4 aut
+700 00 *a Andersen *h Reje *4 aut
+700 00 *a Jensen *h Bente *c f. 1958-01-10 *4 aut
 710 00 *a Selskabet for Ꜳlborgs Historie
 710 00 *a Ꜳlborg Stadsarkiv
 710 00 *a Ꜳlborg Historiske Museum

--- a/src/test/resources/dk/dbc/updateservice/records/record-1-expected.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-1-expected.marc
@@ -13,8 +13,8 @@
 652 00 *m 46.4 *b Løkken
 652 00 *p 46.4 *b Blokhus
 666 00 *& 785100 *e Blokhus
-700 00 *5 870979 *6 68484499 *4 aut
-700 00 *5 870979 *6 68493579 *4 aut
+700 00 *a Andersen *h Reje *4 aut
+700 00 *a Jensen *h Bente *c f. 1958-01-10 *4 aut
 710 00 *a Selskabet for Ꜳlborgs Historie
 710 00 *a Ꜳlborg Stadsarkiv
 710 00 *a Ꜳlborg Historiske Museum

--- a/src/test/resources/dk/dbc/updateservice/records/record-10-existing.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-10-existing.marc
@@ -4,7 +4,7 @@
 009 00 *a a *g xx
 021 00 *e 9788771015201 *c ringordner *d kr. 250,00
 032 00 *x ACC201144 *a DBF201147
-100 00 *5 870979 *6 68997526 *4 aut
+100 00 *a Svarre *h Ole *4 aut
 245 00 *a Historier fra Norden *c kopimappe med opgaver
 260 00 *a [Holbæk] *b Gullhoj *c [2011]
 300 00 *a [12] sider, 20 løsblade *b ill. *c 32 cm

--- a/src/test/resources/dk/dbc/updateservice/records/record-10-expected.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-10-expected.marc
@@ -4,7 +4,7 @@
 009 00 *a a *g xx
 021 00 *e 9788771015201 *c ringordner *d kr. 250,00
 032 00 *x ACC201144 *a DBF201147
-100 00 *5 870979 *6 68997526 *4 aut
+100 00 *a Svarre *h Ole *4 aut
 245 00 *a Historier fra Norden *c kopimappe med opgaver
 260 00 *a [Holbæk] *b Gullhoj *c [2011]
 300 00 *a [12] sider, 20 løsblade *b ill. *c 32 cm

--- a/src/test/resources/dk/dbc/updateservice/records/record-11-existing.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-11-existing.marc
@@ -10,6 +10,6 @@
 652 00 *p 78.69
 652 00 *n 86 *z 091
 652 00 *o sk
-700 00 *5 870979 *6 47482194 *4 aut *4 cmp
-700 00 *5 870979 *6 68594952 *4 aut *4 cmp
+700 00 *a Bayer *h Linda S. *4 aut *4 cmp
+700 00 *a Kværndrup *h Bent *4 aut *4 cmp
 996 00 *a DBC

--- a/src/test/resources/dk/dbc/updateservice/records/record-11-expected.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-11-expected.marc
@@ -11,6 +11,6 @@
 652 00 *p 78.69
 652 00 *n 86 *z 091
 652 00 *o sk
-700 00 *5 870979 *6 47482194 *4 aut *4 cmp
-700 00 *5 870979 *6 68594952 *4 aut *4 cmp
+700 00 *a Bayer *h Linda S. *4 aut *4 cmp
+700 00 *a Kværndrup *h Bent *4 aut *4 cmp
 996 00 *a DBC

--- a/src/test/resources/dk/dbc/updateservice/records/record-3-existing.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-3-existing.marc
@@ -4,7 +4,7 @@
 009 00 *a a *g xx
 021 00 *e 9788771015201 *c ringordner *d kr. 250,00
 032 00 *x ACC201144 *a DBF201147
-100 00 *5 870979 *6 68997526 *4 aut
+100 00 *a Svarre *h Ole *4 aut
 245 00 *a Historier fra Norden *c kopimappe med opgaver
 260 00 *a [Holbæk] *b Gullhoj *c [2011]
 300 00 *a [12] sider, 20 løsblade *b ill. *c 32 cm

--- a/src/test/resources/dk/dbc/updateservice/records/record-3-expected.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-3-expected.marc
@@ -4,7 +4,7 @@
 009 00 *a a *g xx
 021 00 *e 9788771015201 *c ringordner *d kr. 250,00
 032 00 *x ACC201144 *a DBF201147
-100 00 *5 870979 *6 68997526 *4 aut
+100 00 *a Svarre *h Ole *4 aut
 245 00 *a Historier fra Norden *c kopimappe med opgaver
 260 00 *a [Holbæk] *b Gullhoj *c [2011]
 300 00 *a [12] sider, 20 løsblade *b ill. *c 32 cm

--- a/src/test/resources/dk/dbc/updateservice/records/record-4-existing.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-4-existing.marc
@@ -10,6 +10,6 @@
 652 00 *p 78.69
 652 00 *n 86 *z 091
 652 00 *o sk
-700 00 *5 870979 *6 47482194 *4 aut *4 cmp
-700 00 *5 870979 *6 68594952 *4 aut *4 cmp
+700 00 *a Bayer *h Linda S. *4 aut *4 cmp
+700 00 *a Kværndrup *h Bent *4 aut *4 cmp
 996 00 *a DBC

--- a/src/test/resources/dk/dbc/updateservice/records/record-4-expected.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-4-expected.marc
@@ -11,6 +11,6 @@
 652 00 *p 78.69
 652 00 *n 86 *z 091
 652 00 *o sk
-700 00 *5 870979 *6 47482194 *4 aut *4 cmp
-700 00 *5 870979 *6 68594952 *4 aut *4 cmp
+700 00 *a Bayer *h Linda S. *4 aut *4 cmp
+700 00 *a Kværndrup *h Bent *4 aut *4 cmp
 996 00 *a DBC

--- a/src/test/resources/dk/dbc/updateservice/records/record-51256875-existing.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-51256875-existing.marc
@@ -18,7 +18,7 @@
 652 00 *m 90
 666 00 *f historie
 666 00 *f verdenshistorie
-700 00 *5 870979 *6 68414083 *4 dktek *4 edt
+700 00 *å 1001 *a Hawkins-Dady *h Mark *4 dktek *4 edt
 720 00 *o Poul Henrik Westh *4 trl
 720 00 *o Uffe Ellemann Jensen *4 aui
 990 00 *o 201439 *b l *b v *u nu

--- a/src/test/resources/dk/dbc/updateservice/records/record-51256875-expected.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-51256875-expected.marc
@@ -19,7 +19,7 @@
 652 00 *m 90
 666 00 *f historie
 666 00 *f verdenshistorie
-700 00 *5 870979 *6 68414083 *4 dktek *4 edt
+700 00 *å 1001 *a Hawkins-Dady *h Mark *4 dktek *4 edt
 720 00 *o Poul Henrik Westh *4 trl
 720 00 *o Uffe Ellemann Jensen *4 aui
 990 00 *o 201439 *b l *b v *u nu

--- a/src/test/resources/dk/dbc/updateservice/records/record-6-existing.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-6-existing.marc
@@ -4,7 +4,7 @@
 009 00 *a a *g xx
 021 00 *a 87-01-32581-7 *c hf. *d kr. 75.00
 032 00 *a DBF197649 *x SFD197649
-100 00 *5 870979 *6 68260965
+100 00 *a Drewsen *h Jette
 245 00 *a Pause *c roman *e [af] Jette Drewsen
 260 00 *& 1 *a [Kbh.] *b Gyldendal *c 1976 *k Nørhaven, Viborg
 300 00 *a 155 sider *c 22 cm

--- a/src/test/resources/dk/dbc/updateservice/records/record-6-expected.marc
+++ b/src/test/resources/dk/dbc/updateservice/records/record-6-expected.marc
@@ -4,7 +4,7 @@
 009 00 *a a *g xx
 021 00 *a 87-01-32581-7 *c hf. *d kr. 75.00
 032 00 *a DBF197649 *x SFD197649
-100 00 *5 870979 *6 68260965
+100 00 *a Drewsen *h Jette
 245 00 *a Pause *c roman *e [af] Jette Drewsen
 260 00 *& 1 *a [Kbh.] *b Gyldendal *c 1976 *k Nørhaven, Viborg
 300 00 *a 155 sider *c 22 cm


### PR DESCRIPTION
When updating records with A-references, the expanded fields are now matched.